### PR TITLE
add action to move major v tag

### DIFF
--- a/.github/workflows/self-update-major-tag.yml
+++ b/.github/workflows/self-update-major-tag.yml
@@ -3,6 +3,12 @@ name: Release
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        required: false
+        description: The tag to move major version tag to
+        default: ""
 
 jobs:
   build:
@@ -15,8 +21,19 @@ jobs:
 
       - name: version
         id: version
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
-          tag=${GITHUB_REF/refs\/tags\//}
+          if [[ "${INPUT_TAG}" =~ ^v[0-9]+.[0-9]+.[0-9]+$ ]]; then
+            tag="${INPUT_TAG}"
+          fi
+          if [[ ! -z "${GITHUB_REF}" ]] && [[ "${GITHUB_REF}" =~ ^refs/tags/v[0-9]+.[0-9]+.[0-9]+$ ]]; then
+            tag=${GITHUB_REF/refs\/tags\//}
+          fi
+          if [[ -z "${tag}" ]]; then
+            echo "No tag found"
+            exit 1
+          fi
           version=${tag#v}
           major=${version%%.*}
           echo "::set-output name=tag::${tag}"

--- a/.github/workflows/self-update-major-tag.yml
+++ b/.github/workflows/self-update-major-tag.yml
@@ -1,0 +1,29 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: version
+        id: version
+        run: |
+          tag=${GITHUB_REF/refs\/tags\//}
+          version=${tag#v}
+          major=${version%%.*}
+          echo "::set-output name=tag::${tag}"
+          echo "::set-output name=version::${version}"
+          echo "::set-output name=major::${major}"
+
+      - name: force update major tag
+        run: |
+          git tag v${{ steps.version.outputs.major }} ${{ steps.version.outputs.tag }} -f
+          git push origin refs/tags/v${{ steps.version.outputs.major }} -f

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # github-reusable-workflows
 
 Repository for reusable workflows
+
+## Other workflows
+
+We do host some non reusable workflows that is meant to be consumed by repository as in any workflows files starting with `self-`


### PR DESCRIPTION
This allows us to not manually bump major v tag after releases.