### PR TITLE
JDK setup step name was too specific and incorrect

### DIFF
--- a/.github/workflows/maven-cd.yml
+++ b/.github/workflows/maven-cd.yml
@@ -53,7 +53,7 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Set up JDK 8
+    - name: Set up JDK
       uses: actions/setup-java@v3
       with:
         distribution: temurin


### PR DESCRIPTION
The trivial part of https://github.com/jenkins-infra/github-reusable-workflows/pull/6#discussion_r897355185 noted by @jtnord as well as @eduard-tita in https://github.com/jenkinsci/nexus-platform-plugin/pull/206#issuecomment-1156739591.