### PR TITLE
chore: pin GitHub actions with their SHA-1 instead of their version number

### DIFF
--- a/.github/workflows/maven-cd.yml
+++ b/.github/workflows/maven-cd.yml
@@ -17,7 +17,7 @@ jobs:
       should_release: ${{ steps.verify-ci-status.outputs.result == 'success' && steps.interesting-categories.outputs.interesting == 'true' }}
     steps:
       - name: Verify CI status
-        uses: jenkins-infra/verify-ci-status-action@7d194d0c5785a12623f350581db5243063542f90 # v1.2.2
+        uses: jenkins-infra/verify-ci-status-action@v1.2.2
         id: verify-ci-status
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -33,7 +33,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Check interesting categories
-        uses: jenkins-infra/interesting-category-action@78f4b74509528c18790d9c36b2cccb5b21ed3451 # v1.2.1
+        uses: jenkins-infra/interesting-category-action@v1.2.1
         id: interesting-categories
         if: steps.verify-ci-status.outputs.result == 'success'
         with:
@@ -54,7 +54,7 @@ jobs:
           distribution: temurin
           java-version: 11
       - name: Release
-        uses: jenkins-infra/jenkins-maven-cd-action@5f5529707ac2bef1ff86da2553ce465ed669aa65 # v1.3.3
+        uses: jenkins-infra/jenkins-maven-cd-action@v1.3.3
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}

--- a/.github/workflows/maven-cd.yml
+++ b/.github/workflows/maven-cd.yml
@@ -10,7 +10,6 @@ on:
       MAVEN_TOKEN:
         required: true
         description: Maven token used for deploying the plugin jar to Jenkins Artifactory Repository
-
 jobs:
   validate:
     runs-on: ubuntu-latest
@@ -18,14 +17,13 @@ jobs:
       should_release: ${{ steps.verify-ci-status.outputs.result == 'success' && steps.interesting-categories.outputs.interesting == 'true' }}
     steps:
       - name: Verify CI status
-        uses: jenkins-infra/verify-ci-status-action@v1.2.2
+        uses: jenkins-infra/verify-ci-status-action@7d194d0c5785a12623f350581db5243063542f90 # v1.2.2
         id: verify-ci-status
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           output_result: true
-
       - name: Release Drafter
-        uses: release-drafter/release-drafter@v5
+        uses: release-drafter/release-drafter@569eb7ee3a85817ab916c8f8ff03a5bd96c9c83e # v5
         id: draft
         if: steps.verify-ci-status.outputs.result == 'success'
         with:
@@ -34,34 +32,30 @@ jobs:
           version: next
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Check interesting categories
-        uses: jenkins-infra/interesting-category-action@v1.2.1
+        uses: jenkins-infra/interesting-category-action@78f4b74509528c18790d9c36b2cccb5b21ed3451 # v1.2.1
         id: interesting-categories
         if: steps.verify-ci-status.outputs.result == 'success'
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_DRAFT_BODY: ${{ steps.draft.outputs.body }}
-
   release:
     runs-on: ubuntu-latest
     needs: [validate]
     if: needs.validate.outputs.should_release == 'true'
     steps:
-    - name: Check out
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-
-    - name: Set up JDK
-      uses: actions/setup-java@v3
-      with:
-        distribution: temurin
-        java-version: 11
-
-    - name: Release
-      uses: jenkins-infra/jenkins-maven-cd-action@v1.3.3
-      with:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
-        MAVEN_TOKEN: ${{ secrets.MAVEN_TOKEN }}
+      - name: Check out
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 11
+      - name: Release
+        uses: jenkins-infra/jenkins-maven-cd-action@5f5529707ac2bef1ff86da2553ce465ed669aa65 # v1.3.3
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+          MAVEN_TOKEN: ${{ secrets.MAVEN_TOKEN }}

--- a/.github/workflows/self-update-major-tag.yml
+++ b/.github/workflows/self-update-major-tag.yml
@@ -1,5 +1,4 @@
 name: Release
-
 on:
   release:
     types: [published]
@@ -9,7 +8,6 @@ on:
         required: false
         description: The tag to move major version tag to
         default: ""
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -18,7 +16,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-
       - name: version
         id: version
         env:
@@ -39,7 +36,6 @@ jobs:
           echo "tag=${tag}" >> $GITHUB_OUTPUT
           echo "version=${version}" >> $GITHUB_OUTPUT
           echo "major=${major}" >> $GITHUB_OUTPUT
-
       - name: force update major tag
         run: |
           git tag v${{ steps.version.outputs.major }} ${{ steps.version.outputs.tag }} -f


### PR DESCRIPTION
Ref: https://github.com/jenkins-infra/helpdesk/issues/3402