### PR TITLE
Update release-drafter to v6 and bump actions/setup-java to v4

### DIFF
--- a/.github/workflows/maven-cd.yml
+++ b/.github/workflows/maven-cd.yml
@@ -23,7 +23,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           output_result: true
       - name: Release Drafter
-        uses: release-drafter/release-drafter@569eb7ee3a85817ab916c8f8ff03a5bd96c9c83e # v5
+        uses: release-drafter/release-drafter@3f0f87098bd6b5c5b9a36d49c41d998ea58f9348 # v6
         id: draft
         if: steps.verify-ci-status.outputs.result == 'success'
         with:
@@ -49,7 +49,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: 11


### PR DESCRIPTION
The change proposed updates release-drafter to v6 and actions/setup-java to v4 addressing the Node.js 16 deprecation warning.

Fixes #28
Closes #27
Closes #26

Signed-off-by: Alexander Brandes <mc.cache@web.de>
