### PR TITLE
Bump Java to 17

### DIFF
--- a/.github/workflows/maven-cd.yml
+++ b/.github/workflows/maven-cd.yml
@@ -3,12 +3,6 @@
 name: maven-cd
 on:
   workflow_call:
-    inputs:
-      java-version:
-        description: 'The Java version on which jenkins-maven-cd-action is run'
-        default: 11
-        required: false
-        type: number
     secrets:
       MAVEN_USERNAME:
         required: true
@@ -58,7 +52,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: ${{ inputs.java-version }}
+          java-version: 17
       - name: Release
         uses: jenkins-infra/jenkins-maven-cd-action@v1.3.3
         with:

--- a/.github/workflows/maven-cd.yml
+++ b/.github/workflows/maven-cd.yml
@@ -4,7 +4,7 @@ name: maven-cd
 on:
   workflow_call:
     inputs:
-      JAVA_MAJOR_VERSION:
+      java-major-version:
         description: 'The Java major version on which jenkins-maven-cd-action is run'
         default: 11
         required: false
@@ -58,7 +58,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: ${{ inputs.JAVA_MAJOR_VERSION }}
+          java-version: ${{ inputs.java-major-version }}
       - name: Release
         uses: jenkins-infra/jenkins-maven-cd-action@v1.3.3
         with:

--- a/.github/workflows/maven-cd.yml
+++ b/.github/workflows/maven-cd.yml
@@ -4,8 +4,8 @@ name: maven-cd
 on:
   workflow_call:
     inputs:
-      java-major-version:
-        description: 'The Java major version on which jenkins-maven-cd-action is run'
+      java-version:
+        description: 'The Java version on which jenkins-maven-cd-action is run'
         default: 11
         required: false
         type: number
@@ -58,7 +58,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: ${{ inputs.java-major-version }}
+          java-version: ${{ inputs.java-version }}
       - name: Release
         uses: jenkins-infra/jenkins-maven-cd-action@v1.3.3
         with:

--- a/.github/workflows/maven-cd.yml
+++ b/.github/workflows/maven-cd.yml
@@ -3,6 +3,12 @@
 name: maven-cd
 on:
   workflow_call:
+    inputs:
+      JAVA_MAJOR_VERSION:
+        description: 'The Java major version on which jenkins-maven-cd-action is run'
+        default: 11
+        required: false
+        type: number
     secrets:
       MAVEN_USERNAME:
         required: true
@@ -52,7 +58,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 11
+          java-version: ${{ inputs.JAVA_MAJOR_VERSION }}
       - name: Release
         uses: jenkins-infra/jenkins-maven-cd-action@v1.3.3
         with:


### PR DESCRIPTION
This PR bumps java from 11 to 17.

Ref:
- #30

<details><summary>FTR, initial PR body:</summary>

This PR adds an optional input to specify the Java major version to use to run jenkins-maven-cd-action.

Its default value is set to `11` for now, should be updated to `17` when Jenkins controllers will require minimum Java 17 version.

Example of call to use JDK17:

```diff
# Note: additional setup is required, see https://www.jenkins.io/redirect/continuous-delivery-of-plugins

name: cd
on:
  workflow_dispatch:
  check_run:
    types:
      - completed

permissions:
  checks: read
  contents: write

jobs:
  maven-cd:
    uses: jenkins-infra/github-reusable-workflows/.github/workflows/maven-cd.yml@v1
+  with:
+    java-version: 17
    secrets:
      MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
      MAVEN_TOKEN: ${{ secrets.MAVEN_TOKEN }}
```

</details>

Related jenkinsci-dev mailing list thread: https://groups.google.com/g/jenkinsci-dev/c/11P2B9s67tw/m/buquLnLeAwAJ
