### PR TITLE
Enhance maven-cd.yml with an input to run job 'validate' only (job 'release' will be skipped)

### DIFF
--- a/.github/workflows/maven-cd.yml
+++ b/.github/workflows/maven-cd.yml
@@ -3,6 +3,14 @@
 name: maven-cd
 on:
   workflow_call:
+    inputs:
+      validate_only:
+        type: string
+        required: false
+        description: |
+          Validate with release drafter only
+          => Skip release job
+        default: false
     secrets:
       MAVEN_USERNAME:
         required: true
@@ -14,7 +22,8 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     outputs:
-      should_release: ${{ steps.verify-ci-status.outputs.result == 'success' && steps.interesting-categories.outputs.interesting == 'true' }}
+      # If this is being changed, then align step log-should_release-details below!
+      should_release: ${{ inputs.validate_only == 'false' && steps.verify-ci-status.outputs.result == 'success' && steps.interesting-categories.outputs.interesting == 'true' }}
     steps:
       - name: Verify CI status
         uses: jenkins-infra/verify-ci-status-action@v1.2.2
@@ -39,6 +48,23 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_DRAFT_BODY: ${{ steps.draft.outputs.body }}
+      - name: Log should_release details
+        id: log-should_release-details
+        run: |
+          echo "================================"
+          echo "Release job filter details:"
+          echo "          VALIDATE_ONLY: ${VALIDATE_ONLY}"
+          echo "              CI_STATUS: ${CI_STATUS}"
+          echo "   INTERESTING_CATEGORY: ${INTERESTING_CATEGORY}"
+          echo "--------------------------------"
+          echo "=>       SHOULD_RELEASE: ${SHOULD_RELEASE}"
+          echo "================================"
+        env:
+          VALIDATE_ONLY: ${{ inputs.validate_only }}
+          CI_STATUS: ${{ steps.verify-ci-status.outputs.result }}
+          INTERESTING_CATEGORY: ${{ steps.interesting-categories.outputs.interesting }}
+          # This must be equal to output should_release of job validate above!
+          SHOULD_RELEASE: ${{ inputs.validate_only == 'false' && steps.verify-ci-status.outputs.result == 'success' && steps.interesting-categories.outputs.interesting == 'true' }}
   release:
     runs-on: ubuntu-latest
     needs: [validate]


### PR DESCRIPTION
# Motivation / Requirement

Currently the `maven-cd.yml` called by current `cd.yaml` will run a release, in case the Jenkins job build succeeded and there is at least one PR with a category of release interest. In case there is demand to combine more than one PR with an interesting category into same release, one has to disable `check_run` trigger in `cd.yaml` to manually trigger a cd run.

Currently the manual `workflow_dispatch` trigger will run the release job in any case and regardless of the PR categories just if last Jenkins build of the plugin did succeed.

## Enhancement requirement
I would like to have the option to trigger a cd manually, but to perform the `validate` job of `maven-cd.yml` ONLY and to enforce skipping of the release job just to have a review and to check what PRs will get listed by `release-drafter`.
👉 If his PR gets merged, I would like to file another PR for the `cd.yaml` template to provide the validate_only input for `workflow_dispatch`.


# Implementation Details
  - `maven-cd.yml`:
    - add input `validate_only` with default to `false`
    - extend `jobs.validate.outputs.should_release` to `${{ inputs.validate_only == 'false' && ... }}`
    - add step `validate.steps.log-should_release-details` to log details of the `should_release` flag to leverage analysis


# Tests Performed
## Test Case 1:
  - backward compatibility to current cd.yaml template:
    - triggered with an unset (empty) input for validate_only
      => default 'false' effectively used
  - s. https://github.com/jenkinsci/unleash-plugin/actions/runs/10655299938
    - step "Log should_release details" logs:
      ```
      ================================
      Release job filter details:
                VALIDATE_ONLY: false
                    CI_STATUS: success
         INTERESTING_CATEGORY: false
      --------------------------------
      =>       SHOULD_RELEASE: false
      ================================
      ``` 
    - => release is skipped only,
      since there is no interesting category  

## Test Case 2:
  - cd.yaml extended to provide input validate_only to maven-cd.yaml usage:
    - see https://github.com/jenkinsci/unleash-plugin/commit/5dae0ebc1e013eb80c359ee131295e2fffc2a77a
  - s. action run https://github.com/jenkinsci/unleash-plugin/actions/runs/10656729271
    - step "Log should_release details" logs:
      ```
      ================================
      Release job filter details:
                VALIDATE_ONLY: true
                    CI_STATUS: success
         INTERESTING_CATEGORY: false
      --------------------------------
      =>       SHOULD_RELEASE: false
      ================================
      ```
    - => release is skipped,
      since VALIDATE_ONLY is true and there is no interesting category  

## Test Case 3:
  - perform a manually triggerd release with validate_only NOT set
  - s. action run https://github.com/jenkinsci/unleash-plugin/actions/runs/10656834727
    - step "Log should_release details" logs:
      ```
      ================================
      Release job filter details:
                VALIDATE_ONLY: false
                    CI_STATUS: success
         INTERESTING_CATEGORY: true
      --------------------------------
      =>       SHOULD_RELEASE: true
      ================================
      ```
    - => release is performed, since
      - VALIDATE_ONLY is NOT set
      - interesting category is true, since this action was triggered by 'workflow_dispatch'
    - s. release https://github.com/jenkinsci/unleash-plugin/releases/tag/91.v5da_e0eb_c1e01

@lemeurherve @timja - please have a look - thx Markus