### PR TITLE
Use dlcdn instead of downloads.apache.org

### DIFF
--- a/.github/workflows/maven-cd.yml
+++ b/.github/workflows/maven-cd.yml
@@ -88,7 +88,7 @@ jobs:
       # https://github.com/jenkins-infra/github-reusable-workflows/issues/36
       - name: Set up Maven
         run: |
-          wget --no-verbose https://downloads.apache.org/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz
+          wget --no-verbose https://dlcdn.apache.org/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz
           echo $CHECKSUM apache-maven-$MAVEN_VERSION-bin.tar.gz | sha512sum --check
           tar xzf apache-maven-$MAVEN_VERSION-bin.tar.gz
           rm apache-maven-$MAVEN_VERSION-bin.tar.gz


### PR DESCRIPTION
Worth a try?

I've checked and older versions are there too its not just the latest version like it used to be.

(I've checked and the IPs are different to download so it is something different

I think this should be more reliable as its a mirror network instead of an archive? https://infra.apache.org/release-publishing.html

relates to https://github.com/jenkins-infra/github-reusable-workflows/issues/40