### PR TITLE
Update Java version from 17 to 21 for CD

### DIFF
--- a/.github/workflows/maven-cd.yml
+++ b/.github/workflows/maven-cd.yml
@@ -84,7 +84,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
       - name: Release
         uses: jenkins-infra/jenkins-maven-cd-action@v1.4.1
         with:


### PR DESCRIPTION
Java 17 is being slowly removed (typically from Jenkinsfile) (https://github.com/jenkinsci/archetypes/pull/870)

I suggest to move to Java 21 for CD workflows